### PR TITLE
fix: set `Player::ChangeExp` to use internal func

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "reparselib"]
+	path = reparselib
+	url = https://github.com/amdf/reparselib/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "reparselib"]
-	path = reparselib
-	url = https://github.com/amdf/reparselib/

--- a/obse/obse/Commands_MiscReference.cpp
+++ b/obse/obse/Commands_MiscReference.cpp
@@ -871,7 +871,7 @@ public:
 				return false;
 			else
 			{
-				curLifetime = arrow->elapsedTime;
+				curLifetime = arrow->age;
 				return true;
 			}
 
@@ -893,7 +893,7 @@ public:
 
 			if (arrow && arrow->shooter == m_owningActor)
 			{
-				curLifetime = arrow->elapsedTime;
+				curLifetime = arrow->age;
 				return true;
 			}
 
@@ -1366,8 +1366,8 @@ static bool Cmd_GetArrowProjectileEnchantment_Execute(COMMAND_ARGS)
 	if (thisObj)
 	{
 		ArrowProjectile* arrow = (ArrowProjectile*)Oblivion_DynamicCast(thisObj, 0, RTTI_TESObjectREFR, RTTI_ArrowProjectile, 0);
-		if (arrow && arrow->arrowEnch)
-			*refResult = arrow->arrowEnch->refID;
+		if (arrow && arrow->enchantment)
+			*refResult = arrow->enchantment->refID;
 	}
 
 	return true;
@@ -1381,8 +1381,8 @@ static bool Cmd_GetArrowProjectileBowEnchantment_Execute(COMMAND_ARGS)
 	if (thisObj)
 	{
 		ArrowProjectile* arrow = (ArrowProjectile*)Oblivion_DynamicCast(thisObj, 0, RTTI_TESObjectREFR, RTTI_ArrowProjectile, 0);
-		if (arrow && arrow->bowEnch)
-			*refResult = arrow->bowEnch->refID;
+		if (arrow && arrow->bowEnchantment)
+			*refResult = arrow->bowEnchantment->refID;
 	}
 
 	return true;
@@ -1812,7 +1812,7 @@ static bool GetProjectileValue_Execute(COMMAND_ARGS, UInt32 whichValue)
 				*result = arrow->speed;
 				return true;
 			case kProjectile_Time:
-				*result = arrow->elapsedTime;
+				*result = arrow->age;
 				return true;
 			case kProjectile_Distance:
 				// TODO: decode ArrowProjectile class to expose this
@@ -1880,10 +1880,10 @@ static bool SetArrowProjectileValue(COMMAND_ARGS, UInt32 whichValue)
 				arrow->poison = alchItem;
 				break;
 			case kArrow_Enchantment:
-				arrow->arrowEnch = enchItem;
+				arrow->enchantment = enchItem;
 				break;
 			case kArrow_BowEnchantment:
-				arrow->bowEnch = enchItem;
+				arrow->bowEnchantment = enchItem;
 				break;
 			}
 		}

--- a/obse/obse/GameObjects.cpp
+++ b/obse/obse/GameObjects.cpp
@@ -71,6 +71,16 @@ UInt32 Actor::GetBaseActorValue(UInt32 value)
 	return ThisStdCall(s_Actor_GetBaseActorValue, this, value);
 }
 
+void Actor::DrainFatigue(float a_amount)
+{
+	ThisStdCall(0x005E07D0, this, a_amount);
+}
+
+void Actor::UpdateCastPowers(float a_elaspsedTime)
+{
+	ThisStdCall(0x005E7A60, this, a_elaspsedTime);
+}
+
 EquippedItemsList Actor::GetEquippedItems()
 {
 	EquippedItemsList itemList;
@@ -136,6 +146,11 @@ void PlayerCharacter::SetBirthSign(BirthSign* birthSign)
 	ThisStdCall(0x0066A400, this, birthSign);
 }
 
+void PlayerCharacter::UseSkill(UInt32 a_whichSkill, float a_usage, TESSkill* a_skill, bool a_dontIncrementChargenSkillUses)
+{
+	ThisStdCall(0x00668B30, this, a_whichSkill, a_usage, a_skill, a_dontIncrementChargenSkillUses);
+}
+
 float GetGameSettingFloat(const char* settingName)
 {
 	float fVal = 1.0;
@@ -181,20 +196,13 @@ void PlayerCharacter::ChangeExperience(UInt32 valSkill, UInt32 whichUse, float h
 
 void PlayerCharacter::ChangeExperience(UInt32 valSkill, float expChange)
 {
-	float &curExperience = skillExp[valSkill - kActorVal_Armorer];
-	float curSkillLevel = GetBaseActorValue(valSkill);
-	float skillLevel = curSkillLevel;
-
 	if (expChange > 0) {
-		curExperience += expChange;
-		float expNeeded = ExperienceNeeded(valSkill, curSkillLevel);
-		while (expNeeded < curExperience) {
-			curExperience -= expNeeded;
-			skillLevel++;
-			expNeeded = ExperienceNeeded(valSkill, skillLevel);
-		}
-	}
-	else {
+		UseSkill(valSkill, expChange, nullptr, false);
+	} else {
+		float& curExperience = skillExp[valSkill - kActorVal_Armorer];
+		float curSkillLevel = GetBaseActorValue(valSkill);
+		float skillLevel = curSkillLevel;
+
 		expChange = -expChange; // reverse the sign
 		while (curExperience < expChange  && skillLevel > 1) {
 			// we have to reduce the skill by at least a level
@@ -214,13 +222,14 @@ void PlayerCharacter::ChangeExperience(UInt32 valSkill, float expChange)
 		} else {
 			curExperience -= expChange;
 		}
-	}
-	if (skillLevel != curSkillLevel) {
-		SetActorValue(valSkill, skillLevel);
-		SInt32 delta = skillLevel - curSkillLevel;
-		ModSkillAdvanceCount(valSkill, delta);
-		if (GetPlayerClass()->IsMajorSkill(valSkill)) {
-			ModMajorSkillAdvanceCount(delta);
+
+		if (skillLevel != curSkillLevel) {
+			SetActorValue(valSkill, skillLevel);
+			SInt32 delta = skillLevel - curSkillLevel;
+			ModSkillAdvanceCount(valSkill, delta);
+			if (GetPlayerClass()->IsMajorSkill(valSkill)) {
+				ModMajorSkillAdvanceCount(delta);
+			}
 		}
 	}
 }

--- a/obse/obse/GameObjects.h
+++ b/obse/obse/GameObjects.h
@@ -723,7 +723,7 @@ public:
 	virtual void	GetHandReachDistance(void) = 0;   
 	virtual void	SetTransparency(bool on, float amount) = 0;  //Can create or delete ExtraRefractionProperty, set something on the NiAvObject, call a base object vtbl function
 	virtual void	Unk_9D(void) = 0;
-	virtual void	Unk_9E(void) = 0;
+	virtual bool	HasRagDoll() = 0;
 	virtual void	Unk_9F(void) = 0;
 	virtual void	Unk_A0(void) = 0;	// A0
 	virtual SInt32	GetActorValue(UInt32 avCode) = 0;								// current, cumulative value
@@ -807,16 +807,18 @@ public:
 
 	// unk1 looks like quantity, usu. 1; ignored for ammo (equips entire stack)
 	// itemExtraList is NULL as the container changes entry is not resolved before the call
-	void				EquipItem(TESForm * objType, UInt32 unk1, ExtraDataList* itemExtraList, UInt32 unk3, bool lockEquip);
-	void				UnequipItem(TESForm* objType, UInt32 unk1, ExtraDataList* itemExtraList, UInt32 unk3, bool lockUnequip, UInt32 unk5);
-	void				UnequipItemSilent(TESForm* objType, UInt32 unk1, ExtraDataList* itemExtraList, UInt32 unk3, bool lockUnequip, UInt32 unk5);
+	void					EquipItem(TESForm * objType, UInt32 unk1, ExtraDataList* itemExtraList, UInt32 unk3, bool lockEquip);
+	void					UnequipItem(TESForm* objType, UInt32 unk1, ExtraDataList* itemExtraList, UInt32 unk3, bool lockUnequip, UInt32 unk5);
+	void					UnequipItemSilent(TESForm* objType, UInt32 unk1, ExtraDataList* itemExtraList, UInt32 unk3, bool lockUnequip, UInt32 unk5);
 
-	UInt32				GetBaseActorValue(UInt32 value);
-	EquippedItemsList	GetEquippedItems();
+	void					DrainFatigue(float a_amount);
+	UInt32					GetBaseActorValue(UInt32 value);
+	EquippedItemsList		GetEquippedItems();
 	ExtraContainerDataList	GetEquippedEntryDataList();
-	bool				CanCastGreaterPower(SpellItem* power);
-	void				SetCanUseGreaterPower(SpellItem* power, bool bAllowUse, float timer = -1);
-	void				UnequipAllItems();
+	bool					CanCastGreaterPower(SpellItem* power);
+	void					SetCanUseGreaterPower(SpellItem* power, bool bAllowUse, float timer = -1);
+	void					UnequipAllItems();
+	void					UpdateCastPowers(float a_elaspedTime);
 
 	// 8
 	struct PowerListData {
@@ -1085,13 +1087,14 @@ public:
 		return majorSkillAdvances;
 	}
 
-	MagicItem* GetActiveMagicItem();
-	bool IsThirdPerson() { return isThirdPerson ? true : false; }
-	void TogglePOV(bool bFirstPerson);
-	void SetBirthSign(BirthSign* birthSign);
-	void ChangeExperience(UInt32 actorValue, UInt32 scaleIndex, float baseDelta);
-	void ChangeExperience(UInt32 actorValue, float amount);
-	float ExperienceNeeded(UInt32 skill, UInt32 atLevel);
+	MagicItem*	GetActiveMagicItem();
+	bool		IsThirdPerson() { return isThirdPerson ? true : false; }
+	void		TogglePOV(bool bFirstPerson);
+	void		SetBirthSign(BirthSign* birthSign);
+	void		ChangeExperience(UInt32 actorValue, UInt32 scaleIndex, float baseDelta);
+	void		ChangeExperience(UInt32 actorValue, float amount);
+	float		ExperienceNeeded(UInt32 skill, UInt32 atLevel);
+	void		UseSkill(UInt32 a_whichSkill, float a_usage, TESSkill* a_skill, bool a_dontIncrementChargenSkillUses);
 
 	TESClass* GetPlayerClass() const;
 
@@ -1332,30 +1335,50 @@ public:
 	ArrowProjectile();
 	~ArrowProjectile();
 
-	// 54
-	struct CollisionData
+	enum class ArrowCollisionType
 	{
-		// not sure if this data is generated for collisions with immobile objects too, or if struct is unique to ArrowProjectile (probably not)
-		float			unk00[9];	// 00 presumably a matrix or set of 3 3-dimensional vectors
-		TESObjectREFR	* refr;		// 24 what it hit
-		NiNode			* ninode;	// 28 seen "Bip01 Spine" for Creature
-		float			unk2C[9];	// 2C again
+		kStickActor,
+		kStickRef,
+		kStickGround,
+		kBounce,
+		kSimulate,
 	};
 
-	CollisionData	* unk05C;		//05C
-	UInt32			unk060;			//060
-	float			unk064;			//064
-	float			elapsedTime;	//068
-	float			speed;			//06C - base speed * GMST fArrowSpeedMult
-	float			unk070;			//070
-	float			unk074;			//074
-	Actor			* shooter;		//078;
-	EnchantmentItem	* arrowEnch;	//07C
-	EnchantmentItem	* bowEnch;		//080
-	AlchemyItem		* poison;		//084
-	float			unk088;			//088
-	float			unk08C;			//08C
-	float			unk090;			//090
-	UInt32			unk094;			//094
-	UInt32			unk098;			//098
+	enum class ArrowState
+	{
+		kFlying,
+		kCollision,
+		kPostCollision,
+		kDeleting
+	};
+
+	// 54
+	struct CollisionInfo
+	{
+		ArrowCollisionType	collisionType;	// 00
+		float				point[3];		// 04
+		float				normal[3];		// 10
+		float				velocity[3];	// 1C
+		TESObjectREFR*		collidee;		// 28
+		NiAVObject*			closestObject;	// 2C
+		NiMatrix33			rotation;		// 30
+	};
+
+	CollisionInfo*		collisionData;				//05C
+	ArrowState			state;						//060
+	float				fadeAlpha;					//064
+	float				age;						//068
+	float				speed;						//06C - base speed * GMST fArrowSpeedMult
+	float				damage;						//070
+	float				waterSpeed;					//074
+	Actor*				shooter;					//078
+	EnchantmentItem*	enchantment;				//07C
+	EnchantmentItem*	bowEnchantment;				//080
+	AlchemyItem*		poison;						//084
+	float				deltaS[3];					//088
+	bool				needsFinishInitLoadGame;	//094
+	bool				addedToInventory;			//095
+	bool				bowIgnoresWeaponsResist;	//096
+	bool				postForce;					//097
+	UInt32				loadGameFlags;				//098
 };


### PR DESCRIPTION
The original code doesn't properly trigger the game to notify the player about skill increases with corner messages or skill mastery menu popups, and likewise doesn't trigger the OnSkillUse event handler. The UseSkill function that replaces the logic for increasing skill xp does consistently produce these messages, and also applies the same modifications to the passed skill xp amount (with the fSkillUse game settings).

The underlying logic used in the original code does at least seem to function correctly for the purpose of modifying skill xp and setting skill values accordingly, so it's been retained for the negative skill xp code, since it shouldn't 't trigger any of the normal skill increase events anyway.